### PR TITLE
Add ingest Lambda to process S3 uploads

### DIFF
--- a/tests/unit/test_beaconpython_stack.py
+++ b/tests/unit/test_beaconpython_stack.py
@@ -26,3 +26,18 @@ def test_opensearch_domain_created():
             }
         },
     )
+
+
+def test_ingest_lambda_created():
+    app = core.App()
+    stack = BeaconpythonStack(app, "beaconpython")
+    template = assertions.Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Handler": "index.handler",
+            "Runtime": "python3.12",
+            "FunctionName": "IngestFunction",
+        },
+    )


### PR DESCRIPTION
## Summary
- add inline Lambda triggered on S3 uploads
- grant bucket read permissions and connect S3 event
- test Lambda creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dbd14670833190cff50e25a78c48