### PR TITLE
Switch ingest lambda to Docker image

### DIFF
--- a/beaconpython/beaconpython_stack.py
+++ b/beaconpython/beaconpython_stack.py
@@ -48,21 +48,12 @@ class BeaconpythonStack(Stack):
             },
         ).apply_removal_policy(RemovalPolicy.DESTROY)
 
-        # Inline Lambda to process new uploads
-        ingest_function = _lambda.Function(
+        # Docker-based Lambda to process new uploads
+        ingest_function = _lambda.DockerImageFunction(
             self,
             "IngestFunction",
             function_name="IngestFunction",
-            runtime=_lambda.Runtime.PYTHON_3_12,
-            handler="index.handler",
-            code=_lambda.InlineCode(
-                "def handler(event, context):\n"
-                "    # Iterate over incoming records and log the S3 info\n"
-                "    for record in event.get('Records', []):\n"
-                "        bucket = record['s3']['bucket']['name']\n"
-                "        key = record['s3']['object']['key']\n"
-                "        print(f'New object: {key} in bucket: {bucket}')\n"
-            ),
+            code=_lambda.DockerImageCode.from_image_asset("lambda"),
         )
 
         # Allow the function to read from the materials bucket

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,0 +1,9 @@
+FROM amazon/aws-lambda-python:3.12
+
+# Install dependencies
+RUN pip install PyMuPDF
+
+# Copy function code
+COPY index.py ${LAMBDA_TASK_ROOT}
+
+CMD ["index.handler"]

--- a/lambda/index.py
+++ b/lambda/index.py
@@ -1,0 +1,19 @@
+import os
+import tempfile
+import boto3
+import fitz  # PyMuPDF
+
+s3_client = boto3.client('s3')
+
+
+def handler(event, context):
+    for record in event.get('Records', []):
+        bucket = record['s3']['bucket']['name']
+        key = record['s3']['object']['key']
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_path = os.path.join(tmpdir, os.path.basename(key))
+            s3_client.download_file(bucket, key, local_path)
+            with fitz.open(local_path) as doc:
+                text = "".join(page.get_text() for page in doc)
+                print(text)
+    return {'statusCode': 200}

--- a/tests/unit/test_beaconpython_stack.py
+++ b/tests/unit/test_beaconpython_stack.py
@@ -36,8 +36,7 @@ def test_ingest_lambda_created():
     template.has_resource_properties(
         "AWS::Lambda::Function",
         {
-            "Handler": "index.handler",
-            "Runtime": "python3.12",
+            "PackageType": "Image",
             "FunctionName": "IngestFunction",
         },
     )


### PR DESCRIPTION
## Summary
- add Python sources for Lambda in `lambda/`
- build a Docker image with PyMuPDF for PDF extraction
- deploy the ingestion Lambda as a Docker image in the CDK stack
- update tests for the new Lambda package type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e3f08f508331b94a29ee80d2abaf