### PR TITLE
Store embeddings in OpenSearch

### DIFF
--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazon/aws-lambda-python:3.12
 
 # Install dependencies
-RUN pip install PyMuPDF
+RUN pip install PyMuPDF requests requests_aws4auth
 
 # Copy function code
 COPY index.py ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION
## Summary
- send embeddings and source text to OpenSearch
- install requests and requests_aws4auth in Lambda image
- expose OpenSearch endpoint to Lambda and allow ESHttpPut

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f9f131f483319f224347673085dc