### PR TITLE
Add search Lambda and API

### DIFF
--- a/beaconpython/beaconpython_stack.py
+++ b/beaconpython/beaconpython_stack.py
@@ -4,6 +4,7 @@ from aws_cdk import aws_lambda as _lambda
 from aws_cdk import aws_s3_notifications as s3n
 from aws_cdk import aws_opensearchservice as opensearch
 from aws_cdk import aws_iam as iam
+from aws_cdk import aws_apigateway as apigateway
 from constructs import Construct
 
 class BeaconpythonStack(Stack):
@@ -86,5 +87,43 @@ class BeaconpythonStack(Stack):
         materials_bucket.add_event_notification(
             s3.EventType.OBJECT_CREATED,
             s3n.LambdaDestination(ingest_function),
+        )
+
+        # Docker-based Lambda for search queries
+        search_function = _lambda.DockerImageFunction(
+            self,
+            "SearchFunction",
+            function_name="SearchFunction",
+            code=_lambda.DockerImageCode.from_image_asset(
+                "lambda",
+                cmd=["search_function.handler"],
+            ),
+        )
+
+        search_function.add_environment(
+            "OPENSEARCH_ENDPOINT", f"https://{domain.attr_domain_endpoint}"
+        )
+
+        search_function.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["bedrock:InvokeModel"],
+                resources=["*"],
+            )
+        )
+
+        search_function.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["es:ESHttpPost", "es:ESHttpGet"],
+                resources=[
+                    f"arn:aws:es:{Aws.REGION}:{Aws.ACCOUNT_ID}:domain/cert-assistant-search/*"
+                ],
+            )
+        )
+
+        api = apigateway.RestApi(self, "SearchApi", rest_api_name="SearchAPI")
+        search_resource = api.root.add_resource("search")
+        search_resource.add_method(
+            "POST",
+            apigateway.LambdaIntegration(search_function),
         )
 

--- a/tests/unit/test_beaconpython_stack.py
+++ b/tests/unit/test_beaconpython_stack.py
@@ -40,3 +40,25 @@ def test_ingest_lambda_created():
             "FunctionName": "IngestFunction",
         },
     )
+
+
+def test_search_lambda_created():
+    app = core.App()
+    stack = BeaconpythonStack(app, "beaconpython")
+    template = assertions.Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "PackageType": "Image",
+            "FunctionName": "SearchFunction",
+        },
+    )
+
+
+def test_api_gateway_created():
+    app = core.App()
+    stack = BeaconpythonStack(app, "beaconpython")
+    template = assertions.Template.from_stack(stack)
+
+    template.resource_count_is("AWS::ApiGateway::RestApi", 1)


### PR DESCRIPTION
## Summary
- scaffold SearchFunction as Docker Lambda for vector search
- expose SearchFunction through REST API
- test the new SearchFunction and API Gateway resources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bc99e57c83318041a794e3c2c0c1